### PR TITLE
Add Klar for Android

### DIFF
--- a/app/classes/Stores/Project.php
+++ b/app/classes/Stores/Project.php
@@ -51,6 +51,12 @@ class Project
                 'name'     => 'Focus for iOS',
                 'store'    => 'apple',
             ],
+        'klar_android' =>
+            [
+                'channels' => ['release'],
+                'name'     => 'Klar for Android',
+                'store'    => 'google',
+            ],
     ];
 
     /**
@@ -250,6 +256,12 @@ class Project
                 'template'    => 'focus_android/release/listing_mar_2017.php',
                 'listing'     => 'focus_android/description_release.lang',
                 'screenshots' => 'focus_android/screenshots_v1.lang',
+            ],
+        ],
+        'klar_android' => [
+            'release' => [
+                'template'    => 'klar_android/release/listing_mar_2017.php',
+                'listing'     => 'klar_android/description_release.lang',
             ],
         ],
     ];

--- a/app/config/product_sources.json
+++ b/app/config/product_sources.json
@@ -36,5 +36,14 @@
       "format": "txt",
       "source": "https://raw.githubusercontent.com/mozilla-mobile/firefox-ios/v7.x/shipping_locales.txt"
     }
+  ],
+  "klar_android": [
+    {
+      "channel": "release",
+      "format": "array",
+      "source": [
+          "de", "fr", "it"
+      ]
+    }
   ]
 }

--- a/app/config/shipping_locales.json
+++ b/app/config/shipping_locales.json
@@ -136,6 +136,7 @@
       "da", 
       "de", 
       "dsb", 
+      "el", 
       "en-GB", 
       "en-US", 
       "en-ZA", 
@@ -171,6 +172,7 @@
       "kk", 
       "kn", 
       "ko", 
+      "lo", 
       "lt", 
       "lv", 
       "mai", 
@@ -442,6 +444,14 @@
       "uz", 
       "zh-CN", 
       "zh-TW"
+    ]
+  }, 
+  "klar_android": {
+    "release": [
+      "de", 
+      "en-US", 
+      "fr", 
+      "it"
     ]
   }
 }

--- a/app/scripts/update_shipping_locales.py
+++ b/app/scripts/update_shipping_locales.py
@@ -21,12 +21,19 @@ def main():
     shipping_locales = {}
     for product, product_data in update_sources.iteritems():
         for data in product_data:
-            locales = []
-            print('Reading sources for {0} ({1})'.format(product, data['channel']))
-            response = urllib2.urlopen(data['source'])
-            for locale in response:
-                if locale != '' and locale not in locales:
-                    locales.append(locale.rstrip())
+            if data['format'] == 'array':
+                # Hard-coded list of locales
+                locales = data['source']
+            else:
+                # Get locales from a TXT source
+                locales = []
+                print('Reading sources for {0} ({1})'.format(product, data['channel']))
+                response = urllib2.urlopen(data['source'])
+                for locale in response:
+                    if locale != '' and locale not in locales:
+                        locales.append(locale.rstrip())
+
+            # Make sure to add en-US
             if 'en-US' not in locales:
                 locales.append('en-US')
             # Sort locales

--- a/app/templates/klar_android/release/listing_mar_2017.php
+++ b/app/templates/klar_android/release/listing_mar_2017.php
@@ -1,0 +1,37 @@
+<?php
+namespace Stores;
+
+// Include closure needed in template
+include INC . 'utilities.php';
+
+$app_title = function ($translations) use ($_) {
+    return $_('Firefox Klar: Private Browser');
+};
+
+$description = function ($translations) use ($_) {
+    return <<<OUT
+{$_('Browse like no one’s watching.')} {$_('The new Firefox Klar automatically blocks a wide range of online trackers — from the moment you launch it to the second you leave it.')} {$_('Easily erase your history, passwords and cookies, so you won’t get followed by things like unwanted ads.')}
+
+{$_('“Private browsing” on most browsers isn’t comprehensive or easy to use.')} {$_('Klar is next-level privacy that’s free, always on and always on your side — because it’s backed by Mozilla, the non-profit that fights for your rights on the Web.')}
+
+{$_('AUTOMATIC PRIVACY')}
+• {$_('Blocks a wide range of common Web trackers without any settings to set')}
+• {$_('Easily erases your history — no passwords, no cookies, no trackers')}
+
+{$_('BROWSE FASTER')}
+• {$_('By removing trackers and ads, Web pages may require less data and load faster')}
+
+{$_('MADE BY MOZILLA')}
+• {$_('We believe everyone should have control over their lives online. That’s what we’ve been fighting for since 1998.')}
+OUT;
+};
+
+$short_desc = function ($translations) use ($_) {
+    return $_('Get The Privacy Browser. Fast & always private from Firefox, a browser you trust');
+};
+
+$screenshots = function ($translations) use ($_) {
+    return <<<OUT
+{$_('Small download<br>Only 3MB')}
+OUT;
+};

--- a/app/views/klar_android/release/locale_escaped_view.php
+++ b/app/views/klar_android/release/locale_escaped_view.php
@@ -1,0 +1,27 @@
+<h1>Klar for Android Listing Copy (<?= $request['locale'] ?>)</h1>
+
+<h3>Title &mdash; <?= $title_warning ?></h3>
+<pre <?= $direction ?> contenteditable="true"><?= htmlspecialchars($app_title($translations)) ?></pre>
+
+<h3>Short Description &mdash; <?= $short_desc_warning ?></h3>
+<pre <?= $direction ?> contenteditable="true"><?= $short_desc($translations) ?></pre>
+
+<h3>Description &mdash; <?= $listing_warning ?></h3>
+<pre <?= $direction ?> contenteditable="true"><?= strip_tags($description($translations)) ?></pre>
+
+<?php
+    /*
+        Check if the file used for screenshots exists, display this section
+        only in that case.
+    */
+    $screenshot_lang = $project->getLangFiles($request['locale'], $request['product'], $request['channel'], 'screenshots');
+    if ($screenshot_lang) {
+        $locale_file = LOCALES_PATH . $request['locale'] . '/' . array_shift($screenshot_lang);
+        if (file_exists($locale_file)) {
+            ?>
+            <h3>Screenshots</h3>
+            <pre <?= $direction ?> contenteditable="true" class="text-center"><?= br2nl($screenshots($translations)) ?></pre>
+<?php
+
+        }
+    }

--- a/app/views/klar_android/release/locale_view.php
+++ b/app/views/klar_android/release/locale_view.php
@@ -1,0 +1,28 @@
+<h1>Klar for Android Listing Copy (<?= $request['locale'] ?>)</h1>
+
+<h3>Title &mdash; <?= $title_warning ?></h3>
+<pre <?= $direction ?>><?= $app_title($translations) ?></pre>
+
+<h3>Short Description &mdash; <?= $short_desc_warning ?></h3>
+<pre <?= $direction ?>><?= $short_desc($translations) ?></pre>
+
+<h3>Description &mdash; <?= $listing_warning ?></h3>
+<pre <?= $direction ?>><?= $description($translations) ?></pre>
+
+<?php
+    /*
+        Check if the file used for screenshots exists, display this section
+        only in that case.
+    */
+    $screenshot_lang = $project->getLangFiles($request['locale'], $request['product'], $request['channel'], 'screenshots');
+    if ($screenshot_lang) {
+        $locale_file = LOCALES_PATH . $request['locale'] . '/' . array_shift($screenshot_lang);
+        if (file_exists($locale_file)) {
+            ?>
+            <h3>Screenshots</h3>
+            <pre <?= $direction ?> class="text-center"><?= $screenshots($translations) ?></pre>
+<?php
+
+        }
+    }
+?>

--- a/tests/functional/api.php
+++ b/tests/functional/api.php
@@ -36,6 +36,7 @@ $paths = [
     ['v1/fx_android/done/nightly/', 200, false],
     ['v1/fx_ios/done/release/', 200, false],
     ['v1/focus_android/done/release/', 200, false],
+    ['v1/klar_android/done/release/', 200, false],
     ['v1/focus_ios/done/release/', 200, false],
     ['v1/fx_android/translation/release/ja/', 200, false],
     ['v1/fx_android/translation/release/en-US/', 200, false],

--- a/tests/units/Store/Project.php
+++ b/tests/units/Store/Project.php
@@ -56,7 +56,7 @@ class Project extends atoum\test
         $obj = new _Project();
         $this
             ->array($obj->getSupportedProducts())
-                ->isEqualTo(['fx_android', 'fx_ios', 'focus_android', 'focus_ios']);
+                ->isEqualTo(['fx_android', 'fx_ios', 'focus_android', 'focus_ios', 'klar_android']);
     }
 
     public function testGetSupportedStores()


### PR DESCRIPTION
CC @Delphine 

Since updates on Google Play for Focus for Android is fully automated, we end up showing text with "Focus" instead of "Klar" in Switzerland. This exposes a "Klar" product with Italian, French, German translations: I took the original ones and replaced Focus with Klar in the text.