### PR TITLE
Temporary hack to support alternative title for Focus for Android

### DIFF
--- a/app/classes/Stores/Translate.php
+++ b/app/classes/Stores/Translate.php
@@ -142,6 +142,11 @@ class Translate extends DotLangParser
         }
 
         foreach ($this->source_strings as $value) {
+            // HACK: ignore new title for Focus for Android
+            if ($value == 'Firefox Focus: The privacy browser') {
+                continue;
+            }
+
             // Missing string in localized file
             if (! isset($this->translations[$value])) {
                 return false;

--- a/app/models/api_model.php
+++ b/app/models/api_model.php
@@ -94,7 +94,9 @@ if ($request->isTranslationRequired()) {
             }
         }
     }
-    $whatsnew_json = $done;
+    if ($done != ['en-US']) {
+        $whatsnew_json = $done;
+    }
 }
 
 switch ($service) {

--- a/app/templates/focus_android/release/listing_mar_2017.php
+++ b/app/templates/focus_android/release/listing_mar_2017.php
@@ -4,9 +4,16 @@ namespace Stores;
 // Include closure needed in template
 include INC . 'utilities.php';
 
-$app_title = function ($translations) use ($_) {
-    return $_('Firefox Focus: Private Browser');
-};
+// Use new title only if it's translated
+if ($translations->isStringTranslated('Firefox Focus: The privacy browser')) {
+    $app_title = function ($translations) use ($_) {
+        return $_('Firefox Focus: The privacy browser');
+    };
+} else {
+    $app_title = function ($translations) use ($_) {
+        return $_('Firefox Focus: Private Browser');
+    };
+}
 
 $description = function ($translations) use ($_) {
     return <<<OUT

--- a/app/templates/klar_android/release/listing_mar_2017.php
+++ b/app/templates/klar_android/release/listing_mar_2017.php
@@ -5,7 +5,7 @@ namespace Stores;
 include INC . 'utilities.php';
 
 // Use new title only if it's translated
-if ($translations->isStringTranslated('Firefox Focus: The privacy browser')) {
+if ($translations->isStringTranslated('Firefox Klar: The privacy browser')) {
     $app_title = function ($translations) use ($_) {
         return $_('Firefox Klar: The privacy browser');
     };

--- a/app/templates/klar_android/release/listing_mar_2017.php
+++ b/app/templates/klar_android/release/listing_mar_2017.php
@@ -4,9 +4,16 @@ namespace Stores;
 // Include closure needed in template
 include INC . 'utilities.php';
 
-$app_title = function ($translations) use ($_) {
-    return $_('Firefox Klar: Private Browser');
-};
+// Use new title only if it's translated
+if ($translations->isStringTranslated('Firefox Focus: The privacy browser')) {
+    $app_title = function ($translations) use ($_) {
+        return $_('Firefox Klar: The privacy browser');
+    };
+} else {
+    $app_title = function ($translations) use ($_) {
+        return $_('Firefox Klar: Private Browser');
+    };
+}
 
 $description = function ($translations) use ($_) {
     return <<<OUT


### PR DESCRIPTION
For templates it works pretty fine: show the new title if it's translated, show the old one otherwise.

Sadly the hack is needed for API and the main landing page. Will need to remove it as soon as more locales translated that string.