### PR TITLE
Remove What's New from Fennec Nightly (fixes issue #142)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Web App providing the folllowing features:
 
 1. Clone the repository.
 2. Install [Composer](https://getcomposer.org/) and its dependencies with `composer install --no-dev`.
-3. Point a virtual host to the `web` directory.
+3. Point a virtual host to the `web` directory. For debugging, you can also use the internal web server in PHP, running `php -S localhost:8080 -t web` from the root of the repository.
 4. Copy `app/config/config.inc.php.ini` to `config.inc.php` and:
     * Point `$l10n_path` to a clone of the [localization repository](https://github.com/mozilla-l10n/appstores/).
     * Adapt the `$webroot_folder` to your installation.
@@ -18,4 +18,4 @@ You will also need to set up a cron job to update the localization (production s
 
 ## Production instance
 
-Production istance is hosted at https://l10n.mozilla-community.org/stores_l10n/ and updated automatically via GitHub webhooks.
+Production instance is hosted at https://l10n.mozilla-community.org/stores_l10n/ and updated automatically via GitHub webhooks.

--- a/app/classes/Stores/Project.php
+++ b/app/classes/Stores/Project.php
@@ -232,7 +232,7 @@ class Project
             ],
             'nightly' => [
                 'template' => 'fx_android/nightly/listing_may_2017.php',
-                'listing'  => 'fx_android/description_nightly.lang'
+                'listing'  => 'fx_android/description_nightly.lang',
             ],
         ],
         'fx_ios' => [

--- a/app/classes/Stores/Project.php
+++ b/app/classes/Stores/Project.php
@@ -232,8 +232,7 @@ class Project
             ],
             'nightly' => [
                 'template' => 'fx_android/nightly/listing_may_2017.php',
-                'listing'  => 'fx_android/description_nightly.lang',
-                'whatsnew' => 'fx_android/whatsnew/android_nightly.lang',
+                'listing'  => 'fx_android/description_nightly.lang'
             ],
         ],
         'fx_ios' => [

--- a/app/classes/Stores/Translate.php
+++ b/app/classes/Stores/Translate.php
@@ -142,11 +142,6 @@ class Translate extends DotLangParser
         }
 
         foreach ($this->source_strings as $value) {
-            // HACK: ignore new title for Focus for Android
-            if ($value == 'Firefox Focus: The privacy browser') {
-                continue;
-            }
-
             // Missing string in localized file
             if (! isset($this->translations[$value])) {
                 return false;

--- a/app/models/api_model.php
+++ b/app/models/api_model.php
@@ -134,10 +134,13 @@ switch ($service) {
             ];
         }
 
-        // Do we have a Whatsnew file for this release ?
-        if (isset($whatsnew)) {
-            $json['whatsnew'] = $whatsnew($translations);
-        }
+        /*
+            Always expose a "whatsnew" key in the JSON file, leave it empty in
+            case there's no content for this version.
+        */
+        $json['whatsnew'] = isset($whatsnew)
+            ? $whatsnew($translations)
+            : '';
         break;
     case 'whatsnew':
         $json = $whatsnew_json;

--- a/app/templates/fx_android/nightly/listing_may_2017.php
+++ b/app/templates/fx_android/nightly/listing_may_2017.php
@@ -43,11 +43,3 @@ $short_desc = function ($translations) use ($_) {
 $app_title = function ($translations) use ($_) {
     return $_('Firefox Nightly for Developers');
 };
-
-$whatsnew = function ($translations) use ($_, $replacements) {
-    return <<<OUT
-{$_('Your app is up to date!')}
-
-{$_('Firefox Aurora is no longer available and has transitioned to Firefox Nightly in order to streamline our releases and get new features quickly out to users. No action is needed from you - just keep supporting the open web by using this developer version of Firefox. More details here: {{dawn_post}}', $replacements)}
-OUT;
-};

--- a/app/views/fx_android/nightly/locale_escaped_view.php
+++ b/app/views/fx_android/nightly/locale_escaped_view.php
@@ -3,9 +3,6 @@
 <h3>Title &mdash; <?= $title_warning ?></h3>
 <pre <?= $direction ?>><?= $app_title($translations) ?></pre>
 
-<h3>What’s new &mdash; <?= $whatsnew_warning ?></h3>
-<pre <?= $direction ?> contenteditable="true"><?= $whatsnew($translations) ?></pre>
-
 <h3>Short Description &mdash; <?= $short_desc_warning ?></h3>
 <pre <?= $direction ?> contenteditable="true"><em><?= $short_desc($translations) ?></em></pre>
 

--- a/app/views/fx_android/nightly/locale_view.php
+++ b/app/views/fx_android/nightly/locale_view.php
@@ -3,9 +3,6 @@
 <h3>Title &mdash; <?= $title_warning ?></h3>
 <pre <?= $direction ?>><?= $app_title($translations) ?></pre>
 
-<h3>What’s new &mdash; <?= $whatsnew_warning ?></h3>
-<pre <?= $direction ?>><?= $whatsnew($translations) ?></pre>
-
 <h3>Short Description &mdash; <?= $short_desc_warning ?></h3>
 <pre <?= $direction ?> contenteditable="true"><em><?= $short_desc($translations) ?></em></pre>
 

--- a/tests/functional/api.php
+++ b/tests/functional/api.php
@@ -46,7 +46,6 @@ $paths = [
     ['v1/fx_android/translation/nightly/en-US/', 200, false],
     ['v1/fx_android/whatsnew/release/', 200, false],
     ['v1/fx_android/whatsnew/beta/', 200, false],
-    ['v1/fx_android/whatsnew/nightly/', 200, false],
     ['v1/fx_ios/whatsnew/release/', 200, false],
     ['v1/focus_ios/whatsnew/release/', 200, false],
     ['v1/fx_android/listing/release/', 200, false],


### PR DESCRIPTION
This removes What's section from templates, but also make sure what a `whatsnew` key is always available in the JSON.

This fixes issue #142 

@jcristau
When it's the best moment to merge this?